### PR TITLE
add: MIDIのノート番号を構造体として定義して音を鳴らす機能

### DIFF
--- a/PlayMIDI.xcodeproj/project.pbxproj
+++ b/PlayMIDI.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		EB71FA5B2C5A4249004B6E85 /* Play.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB71FA5A2C5A4249004B6E85 /* Play.swift */; };
 		EBD72B9B2C5CDB120076894F /* audio.mid in Resources */ = {isa = PBXBuildFile; fileRef = EBD72B992C5CDB120076894F /* audio.mid */; };
 		EBD72BC82C5CF9940076894F /* soundfont.sf2 in Resources */ = {isa = PBXBuildFile; fileRef = EBD72BC72C5CF9940076894F /* soundfont.sf2 */; };
+		EBD72BCA2C61FF8B0076894F /* MIDINotePlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD72BC92C61FF8B0076894F /* MIDINotePlay.swift */; };
+		EBD72BCC2C6200FC0076894F /* MIDINoteData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD72BCB2C6200FC0076894F /* MIDINoteData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +32,8 @@
 		EB71FA5A2C5A4249004B6E85 /* Play.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Play.swift; sourceTree = "<group>"; };
 		EBD72B992C5CDB120076894F /* audio.mid */ = {isa = PBXFileReference; lastKnownFileType = audio.midi; path = audio.mid; sourceTree = SOURCE_ROOT; };
 		EBD72BC72C5CF9940076894F /* soundfont.sf2 */ = {isa = PBXFileReference; lastKnownFileType = file; path = soundfont.sf2; sourceTree = SOURCE_ROOT; };
+		EBD72BC92C61FF8B0076894F /* MIDINotePlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDINotePlay.swift; sourceTree = "<group>"; };
+		EBD72BCB2C6200FC0076894F /* MIDINoteData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDINoteData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +73,8 @@
 				EB71FA492C5A4232004B6E85 /* PlayMIDIApp.swift */,
 				EB71FA4B2C5A4232004B6E85 /* ContentView.swift */,
 				EB71FA5A2C5A4249004B6E85 /* Play.swift */,
+				EBD72BCB2C6200FC0076894F /* MIDINoteData.swift */,
+				EBD72BC92C61FF8B0076894F /* MIDINotePlay.swift */,
 				EB71FA4D2C5A4232004B6E85 /* ImmersiveView.swift */,
 				EB71FA4F2C5A4233004B6E85 /* Assets.xcassets */,
 				EB71FA542C5A4233004B6E85 /* Info.plist */,
@@ -169,7 +175,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				EB71FA4C2C5A4232004B6E85 /* ContentView.swift in Sources */,
+				EBD72BCA2C61FF8B0076894F /* MIDINotePlay.swift in Sources */,
 				EB71FA4A2C5A4232004B6E85 /* PlayMIDIApp.swift in Sources */,
+				EBD72BCC2C6200FC0076894F /* MIDINoteData.swift in Sources */,
 				EB71FA4E2C5A4232004B6E85 /* ImmersiveView.swift in Sources */,
 				EB71FA5B2C5A4249004B6E85 /* Play.swift in Sources */,
 			);

--- a/PlayMIDI/ContentView.swift
+++ b/PlayMIDI/ContentView.swift
@@ -16,6 +16,9 @@ struct ContentView: View {
     @State private var player: Play = Play(midiFile: "audio",soundFontFile: "soundfont")
     @State private var notePlayer: MIDINotePlay = MIDINotePlay(soundFontFile: "soundfont")
     
+    @State private var selectedMIDI: UInt8 = 0
+    @State private var midiNoteData = MIDINoteData()
+    
     @Environment(\.openImmersiveSpace) var openImmersiveSpace
     @Environment(\.dismissImmersiveSpace) var dismissImmersiveSpace
     
@@ -43,13 +46,22 @@ struct ContentView: View {
                         .scaledToFit()
                         .frame(width: 100)
                         .onTapGesture {
-                            notePlayer.allPlay()
+                            if(!midiNoteData.existsMidiData(number: selectedMIDI)){
+                                print("キーが存在しません")
+                                return
+                            }
+                            notePlayer.play(midinote: midiNoteData.getMidiDataFromNumber(number: selectedMIDI))
                         }
                 }
                 Spacer(minLength: 10)
             }
             
-            Text("Hello, world!")
+            Picker("鳴らすMIDIデータの選択", selection: $selectedMIDI) {
+                ForEach(midiNoteData.getAllMidiNotes(), id: \.number) { note in
+                    Text(note.name).tag(note.number)
+                }
+            }
+            .pickerStyle(MenuPickerStyle())
             
             Toggle("Show ImmersiveSpace", isOn: $showImmersiveSpace)
                 .font(.title)

--- a/PlayMIDI/ContentView.swift
+++ b/PlayMIDI/ContentView.swift
@@ -14,19 +14,40 @@ struct ContentView: View {
     @State private var showImmersiveSpace = false
     @State private var immersiveSpaceIsShown = false
     @State private var player: Play = Play(midiFile: "audio",soundFontFile: "soundfont")
+    @State private var notePlayer: MIDINotePlay = MIDINotePlay(soundFontFile: "soundfont")
     
     @Environment(\.openImmersiveSpace) var openImmersiveSpace
     @Environment(\.dismissImmersiveSpace) var dismissImmersiveSpace
     
     var body: some View {
         VStack {
-            Image(systemName: "waveform.circle")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 100)
-                .onTapGesture {
-                    player.play()
+            HStack{
+                Spacer(minLength: 10)
+                
+                VStack{
+                    Text("MIDI音源の再生")
+                    Image(systemName: "waveform.circle")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 100)
+                        .onTapGesture {
+                            player.play()
+                        }
                 }
+                Spacer(minLength: 10)
+                
+                VStack{
+                    Text("MIDIデータを作って音を鳴らす")
+                    Image(systemName: "speaker.wave.2.circle")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 100)
+                        .onTapGesture {
+                            notePlayer.allPlay()
+                        }
+                }
+                Spacer(minLength: 10)
+            }
             
             Text("Hello, world!")
             

--- a/PlayMIDI/MIDINoteData.swift
+++ b/PlayMIDI/MIDINoteData.swift
@@ -14,7 +14,7 @@ class MIDINoteData{
     private final let noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
     
     private var midiNotes: [MIDINote]
-        
+    
     init() {
         var notes = [MIDINote]()
         
@@ -28,6 +28,17 @@ class MIDINoteData{
         self.midiNotes = notes
     }
     
+    func existsMidiData(number: UInt8) -> Bool {
+        return midiNotes.contains { $0.number == number }
+    }
+    
+    func getMidiDataFromNumber(number: UInt8) -> MIDINote {
+        if let note = midiNotes.first(where: { $0.number == number }) {
+            return note
+        }
+        return midiNotes[0]
+    }
+
     func getAllMidiNotes() -> [MIDINote] {
         return midiNotes
     }

--- a/PlayMIDI/MIDINoteData.swift
+++ b/PlayMIDI/MIDINoteData.swift
@@ -1,0 +1,34 @@
+//
+//  MIDINoteNumber.swift
+//  PlayMIDI
+//
+//  Created by blue ken on 2024/08/06.
+//
+
+struct MIDINote {
+    var number: UInt8
+    var name: String
+}
+
+class MIDINoteData{
+    private final let noteNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+    
+    private var midiNotes: [MIDINote]
+        
+    init() {
+        var notes = [MIDINote]()
+        
+        for i in 0...127 {
+            let octave = (i / 12) - 1
+            let name = noteNames[i % 12]
+            let noteName = "\(name)\(octave)"
+            notes.append(MIDINote(number: UInt8(i), name: noteName))
+        }
+        
+        self.midiNotes = notes
+    }
+    
+    func getAllMidiNotes() -> [MIDINote] {
+        return midiNotes
+    }
+}

--- a/PlayMIDI/MIDINotePlay.swift
+++ b/PlayMIDI/MIDINotePlay.swift
@@ -1,0 +1,76 @@
+//
+//  NotePlay.swift
+//  PlayMIDI
+//
+//  Created by blue ken on 2024/08/06.
+//
+
+import AVFoundation
+
+class MIDINotePlay{
+    // ライブラリの初期化
+    private let audioEngine = AVAudioEngine()
+    private let unitSampler = AVAudioUnitSampler()
+    
+    // ピアノ音源の適応
+    private let soundFontFile: String
+    
+    // 再生する音の設定
+    private final var midiNoteData = MIDINoteData()
+
+    init(soundFontFile: String) {
+        self.soundFontFile = soundFontFile
+        audioEngine.attach(unitSampler)
+        audioEngine.connect(unitSampler, to: audioEngine.mainMixerNode, format: nil)
+        try? audioEngine.start()
+        loadSoundFont()
+    }
+    
+    func loadSoundFont() {
+        guard let url = Bundle.main.url(forResource: soundFontFile, withExtension: "sf2") else { return }
+        try? unitSampler.loadSoundBankInstrument(
+            at: url, program: 0,
+            bankMSB: UInt8(kAUSampler_DefaultMelodicBankMSB),
+            bankLSB: UInt8(kAUSampler_DefaultBankLSB)
+        )
+    }
+    
+    deinit {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+            audioEngine.disconnectNodeOutput(unitSampler)
+            audioEngine.detach(unitSampler)
+        }
+    }
+    
+    func play(midinote: MIDINote) {
+        // 一つ目の引数はMIDIのNote番号
+        // withVelocityは音量に関係する値 0 ~ 127
+        // onChannelはチャンネルを構成しないなら基本0
+        dump(midinote)
+        unitSampler.startNote(midinote.number, withVelocity: 80, onChannel: 0)
+    }
+    
+    func stop(midinote: MIDINote) {
+        unitSampler.stopNote(midinote.number, onChannel: 0)
+    }
+    
+    func allPlay() {
+        // 音を鳴らす時間（秒）
+        let noteDuration: TimeInterval = 0.5
+        
+        let midiNotes = midiNoteData.getAllMidiNotes()
+        
+        for (index, midinote) in midiNotes.enumerated() {
+            let delay = Double(index) * noteDuration
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                self.play(midinote: midinote)
+                
+                // 音を鳴らしてから音が消えるまで待つ
+                DispatchQueue.main.asyncAfter(deadline: .now() + noteDuration) {
+                    self.stop(midinote: midinote)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# やったこと
- MIDIのノート番号と音の名前を構造体として定義
- MIDIの音階に合わせて音を再生する機能の実装